### PR TITLE
Fix path & file creation issue of `makecmd`

### DIFF
--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -57,7 +57,7 @@ end
 
 @cast function pw(
     input,
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -82,7 +82,7 @@ end
 
 @cast function ph(
     input,
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -107,7 +107,7 @@ end
 
 @cast function q2r(
     input,
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -132,7 +132,7 @@ end
 
 @cast function matdyn(
     input,
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -157,7 +157,7 @@ end
 
 @cast function dynmat(
     input,
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -193,7 +193,7 @@ end
 
 function makecmd(
     input;
-    output = tempname(parentdir(input)),
+    output = mktemp(parentdir(input))[1],
     error = output,
     dir = parentdir(input),
     use_script = false,
@@ -225,8 +225,8 @@ function makecmd(
             mkpath(dir)
         end
         str = join(args, " ")
-        script = tempname(dir)
-        write(script, str)
+        script, io = mktemp(dir)
+        write(io, str)
         chmod(script, 0o755)
         return setenv(Cmd([abspath(script)]), ENV; dir = dir)
     else

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -55,40 +55,29 @@ end
     dynmat::DynmatxConfig = DynmatxConfig()
 end
 
-# There are three directories, `pwd()`, the location of `cfgfile`, and the location of `input`.
 @cast function pw(
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
-    config = PwxConfig(),
+    main = PwxConfig(),
     cfgfile = "",
 )
-    if isempty(cfgfile)
-        cmd = makecmd(
-            input;
-            output = output,
-            error = error,
-            use_script = use_script,
-            mpi = mpi,
-            main = config,
-        )
-        return run(cmd)
-    else
+    if !isempty(cfgfile)
         config = readconfig(cfgfile)
-        cd(expanduser(dirname(cfgfile))) do
-            cmd = makecmd(
-                input;
-                output = output,
-                error = error,
-                use_script = use_script,
-                mpi = config.mpi,
-                main = config.pw,
-            )
-            return run(cmd)
-        end
+        mpi, main = config.mpi, config.pw
     end
+    cmd = makecmd(
+        input;
+        output = output,
+        error = error,
+        dir = expanduser(dirname(input)),
+        use_script = use_script,
+        mpi = mpi,
+        main = main,
+    )
+    return run(cmd)
 end
 
 @cast function ph(
@@ -97,33 +86,23 @@ end
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
-    config = PhxConfig(),
+    main = PwxConfig(),
     cfgfile = "",
 )
-    if isempty(cfgfile)
-        cmd = makecmd(
-            input;
-            output = output,
-            error = error,
-            use_script = use_script,
-            mpi = mpi,
-            main = config,
-        )
-        return run(cmd)
-    else
+    if !isempty(cfgfile)
         config = readconfig(cfgfile)
-        cd(expanduser(dirname(cfgfile))) do
-            cmd = makecmd(
-                input;
-                output = output,
-                error = error,
-                use_script = use_script,
-                mpi = config.mpi,
-                main = config.ph,
-            )
-            return run(cmd)
-        end
+        mpi, main = config.mpi, config.ph
     end
+    cmd = makecmd(
+        input;
+        output = output,
+        error = error,
+        dir = expanduser(dirname(input)),
+        use_script = use_script,
+        mpi = mpi,
+        main = main,
+    )
+    return run(cmd)
 end
 
 @cast function q2r(
@@ -132,33 +111,23 @@ end
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
-    config = Q2rxConfig(),
+    main = PwxConfig(),
     cfgfile = "",
 )
-    if isempty(cfgfile)
-        cmd = makecmd(
-            input;
-            output = output,
-            error = error,
-            use_script = use_script,
-            mpi = mpi,
-            main = config,
-        )
-        return run(cmd)
-    else
+    if !isempty(cfgfile)
         config = readconfig(cfgfile)
-        cd(expanduser(dirname(cfgfile))) do
-            cmd = makecmd(
-                input;
-                output = output,
-                error = error,
-                use_script = use_script,
-                mpi = config.mpi,
-                main = config.q2r,
-            )
-            return run(cmd)
-        end
+        mpi, main = config.mpi, config.q2r
     end
+    cmd = makecmd(
+        input;
+        output = output,
+        error = error,
+        dir = expanduser(dirname(input)),
+        use_script = use_script,
+        mpi = mpi,
+        main = main,
+    )
+    return run(cmd)
 end
 
 @cast function matdyn(
@@ -167,33 +136,23 @@ end
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
-    config = MatdynxConfig(),
+    main = PwxConfig(),
     cfgfile = "",
 )
-    if isempty(cfgfile)
-        cmd = makecmd(
-            input;
-            output = output,
-            error = error,
-            use_script = use_script,
-            mpi = mpi,
-            main = config,
-        )
-        return run(cmd)
-    else
+    if !isempty(cfgfile)
         config = readconfig(cfgfile)
-        cd(expanduser(dirname(cfgfile))) do
-            cmd = makecmd(
-                input;
-                output = output,
-                error = error,
-                use_script = use_script,
-                mpi = config.mpi,
-                main = config.matdyn,
-            )
-            return run(cmd)
-        end
+        mpi, main = config.mpi, config.matdyn
     end
+    cmd = makecmd(
+        input;
+        output = output,
+        error = error,
+        dir = expanduser(dirname(input)),
+        use_script = use_script,
+        mpi = mpi,
+        main = main,
+    )
+    return run(cmd)
 end
 
 @cast function dynmat(
@@ -202,33 +161,23 @@ end
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
-    config = DynmatxConfig(),
+    main = PwxConfig(),
     cfgfile = "",
 )
-    if isempty(cfgfile)
-        cmd = makecmd(
-            input;
-            output = output,
-            error = error,
-            use_script = use_script,
-            mpi = mpi,
-            main = config,
-        )
-        return run(cmd)
-    else
+    if !isempty(cfgfile)
         config = readconfig(cfgfile)
-        cd(expanduser(dirname(cfgfile))) do
-            cmd = makecmd(
-                input;
-                output = output,
-                error = error,
-                use_script = use_script,
-                mpi = config.mpi,
-                main = config.dynmat,
-            )
-            return run(cmd)
-        end
+        mpi, main = config.mpi, config.dynmat
     end
+    cmd = makecmd(
+        input;
+        output = output,
+        error = error,
+        dir = expanduser(dirname(input)),
+        use_script = use_script,
+        mpi = mpi,
+        main = main,
+    )
+    return run(cmd)
 end
 
 function readconfig(cfgfile)

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -57,7 +57,7 @@ end
 
 @cast function pw(
     input,
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -82,7 +82,7 @@ end
 
 @cast function ph(
     input,
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -107,7 +107,7 @@ end
 
 @cast function q2r(
     input,
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -132,7 +132,7 @@ end
 
 @cast function matdyn(
     input,
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -157,7 +157,7 @@ end
 
 @cast function dynmat(
     input,
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -193,7 +193,7 @@ end
 
 function makecmd(
     input;
-    output = tempname(expanduser(dirname(input)); cleanup = false),
+    output = tempname(expanduser(dirname(input))),
     error = output,
     dir = expanduser(dirname(input)),
     use_script = false,
@@ -225,7 +225,7 @@ function makecmd(
             mkpath(dir)
         end
         str = join(args, " ")
-        script = tempname(dir; cleanup = false)
+        script = tempname(dir)
         write(script, str)
         chmod(script, 0o755)
         return setenv(Cmd([abspath(script)]), ENV; dir = dir)

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -246,6 +246,7 @@ function makecmd(
     input;
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output,
+    dir = expanduser(dirname(input)),
     use_script = false,
     mpi = MpiexecConfig(),
     main,
@@ -265,7 +266,6 @@ function makecmd(
             push!(args, "-$f", string(v))
         end
     end
-    dir = main.chdir ? expanduser(dirname(input)) : pwd()
     if !use_script
         for (k, v) in zip(("-inp", "1>", "2>"), (input, output, error))
             if v !== nothing

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -57,7 +57,7 @@ end
 
 @cast function pw(
     input,
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -72,7 +72,7 @@ end
         input;
         output = output,
         error = error,
-        dir = expanduser(dirname(input)),
+        dir = parentdir(input),
         use_script = use_script,
         mpi = mpi,
         main = main,
@@ -82,7 +82,7 @@ end
 
 @cast function ph(
     input,
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -97,7 +97,7 @@ end
         input;
         output = output,
         error = error,
-        dir = expanduser(dirname(input)),
+        dir = parentdir(input),
         use_script = use_script,
         mpi = mpi,
         main = main,
@@ -107,7 +107,7 @@ end
 
 @cast function q2r(
     input,
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -122,7 +122,7 @@ end
         input;
         output = output,
         error = error,
-        dir = expanduser(dirname(input)),
+        dir = parentdir(input),
         use_script = use_script,
         mpi = mpi,
         main = main,
@@ -132,7 +132,7 @@ end
 
 @cast function matdyn(
     input,
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -147,7 +147,7 @@ end
         input;
         output = output,
         error = error,
-        dir = expanduser(dirname(input)),
+        dir = parentdir(input),
         use_script = use_script,
         mpi = mpi,
         main = main,
@@ -157,7 +157,7 @@ end
 
 @cast function dynmat(
     input,
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output;
     use_script = false,
     mpi = MpiexecConfig(),
@@ -172,7 +172,7 @@ end
         input;
         output = output,
         error = error,
-        dir = expanduser(dirname(input)),
+        dir = parentdir(input),
         use_script = use_script,
         mpi = mpi,
         main = main,
@@ -193,9 +193,9 @@ end
 
 function makecmd(
     input;
-    output = tempname(expanduser(dirname(input))),
+    output = tempname(parentdir(input)),
     error = output,
-    dir = expanduser(dirname(input)),
+    dir = parentdir(input),
     use_script = false,
     mpi = MpiexecConfig(),
     main,
@@ -233,6 +233,14 @@ function makecmd(
         push!(args, "-inp", "$input")
         return pipeline(setenv(Cmd(args), ENV; dir = dir), stdout = output, stderr = error)
     end
+end
+
+function parentdir(file)
+    dir = dirname(expanduser(file))
+    if isempty(dir)
+        dir = pwd()
+    end
+    return abspath(dir)
 end
 
 """

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -221,17 +221,21 @@ function makecmd(
                 push!(args, k, "'$v'")
             end
         end
+        str = join(args, " ")
         if !isdir(dir)
             mkpath(dir)
         end
-        str = join(args, " ")
         script, io = mktemp(dir)
         write(io, str)
         chmod(script, 0o755)
-        return setenv(Cmd([abspath(script)]), ENV; dir = dir)
+        return setenv(Cmd([abspath(script)]), ENV; dir = abspath(dir))
     else
         push!(args, "-inp", "$input")
-        return pipeline(setenv(Cmd(args), ENV; dir = dir), stdout = output, stderr = error)
+        return pipeline(
+            setenv(Cmd(args), ENV; dir = abspath(dir)),
+            stdout = output,
+            stderr = error,
+        )
     end
 end
 

--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -60,7 +60,7 @@ end
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     config = PwxConfig(),
     cfgfile = "",
@@ -70,7 +70,7 @@ end
             input;
             output = output,
             error = error,
-            as_script = as_script,
+            use_script = use_script,
             mpi = mpi,
             main = config,
         )
@@ -82,7 +82,7 @@ end
                 input;
                 output = output,
                 error = error,
-                as_script = as_script,
+                use_script = use_script,
                 mpi = config.mpi,
                 main = config.pw,
             )
@@ -95,7 +95,7 @@ end
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     config = PhxConfig(),
     cfgfile = "",
@@ -105,7 +105,7 @@ end
             input;
             output = output,
             error = error,
-            as_script = as_script,
+            use_script = use_script,
             mpi = mpi,
             main = config,
         )
@@ -117,7 +117,7 @@ end
                 input;
                 output = output,
                 error = error,
-                as_script = as_script,
+                use_script = use_script,
                 mpi = config.mpi,
                 main = config.ph,
             )
@@ -130,7 +130,7 @@ end
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     config = Q2rxConfig(),
     cfgfile = "",
@@ -140,7 +140,7 @@ end
             input;
             output = output,
             error = error,
-            as_script = as_script,
+            use_script = use_script,
             mpi = mpi,
             main = config,
         )
@@ -152,7 +152,7 @@ end
                 input;
                 output = output,
                 error = error,
-                as_script = as_script,
+                use_script = use_script,
                 mpi = config.mpi,
                 main = config.q2r,
             )
@@ -165,7 +165,7 @@ end
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     config = MatdynxConfig(),
     cfgfile = "",
@@ -175,7 +175,7 @@ end
             input;
             output = output,
             error = error,
-            as_script = as_script,
+            use_script = use_script,
             mpi = mpi,
             main = config,
         )
@@ -187,7 +187,7 @@ end
                 input;
                 output = output,
                 error = error,
-                as_script = as_script,
+                use_script = use_script,
                 mpi = config.mpi,
                 main = config.matdyn,
             )
@@ -200,7 +200,7 @@ end
     input,
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output;
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     config = DynmatxConfig(),
     cfgfile = "",
@@ -210,7 +210,7 @@ end
             input;
             output = output,
             error = error,
-            as_script = as_script,
+            use_script = use_script,
             mpi = mpi,
             main = config,
         )
@@ -222,7 +222,7 @@ end
                 input;
                 output = output,
                 error = error,
-                as_script = as_script,
+                use_script = use_script,
                 mpi = config.mpi,
                 main = config.dynmat,
             )
@@ -246,7 +246,7 @@ function makecmd(
     input;
     output = tempname(expanduser(dirname(input)); cleanup = false),
     error = output,
-    as_script = "",
+    use_script = false,
     mpi = MpiexecConfig(),
     main,
 )
@@ -266,7 +266,7 @@ function makecmd(
         end
     end
     dir = main.chdir ? expanduser(dirname(input)) : pwd()
-    if !isempty(as_script)
+    if !use_script
         for (k, v) in zip(("-inp", "1>", "2>"), (input, output, error))
             if v !== nothing
                 push!(args, k, "'$v'")
@@ -276,9 +276,10 @@ function makecmd(
             mkpath(dir)
         end
         str = join(args, " ")
-        write(as_script, str)
-        chmod(as_script, 0o755)
-        return setenv(Cmd([abspath(as_script)]), ENV; dir = dir)
+        script = tempname(dir; cleanup = false)
+        write(script, str)
+        chmod(script, 0o755)
+        return setenv(Cmd([abspath(script)]), ENV; dir = dir)
     else
         push!(args, "-inp", "$input")
         return pipeline(setenv(Cmd(args), ENV; dir = dir), stdout = output, stderr = error)


### PR DESCRIPTION
There were 4 directories, `pwd()`, the location of `cfgfile`, the location of `input`, and the location of `as_script`. Too many! Have to simplify down to 2 locations. The location of `cfgfile` and the location of `as_script` are not important, so they are gone. Only `pwd()` and the location of `input` are preserved.
Also fixed `mktemp` and `dirname` issues, where `dirname` will return an empty string if the input file path is just the file's name.