### PR TITLE
fix: `Cmd.dir` does not work, I have to use `cd`

### DIFF
--- a/src/QuantumESPRESSOCommands.jl
+++ b/src/QuantumESPRESSOCommands.jl
@@ -290,8 +290,10 @@ function makecmd(input; output = mktemp(parentdir(input))[1], mpi = MpiexecConfi
             push!(args, "-$name", string(value))
         end
     end
-    dir = main.chdir ? parentdir(input) : pwd()
-    return pipeline(addenv(f(args; dir = dir), main.env); stdin = input, stdout = output)
+    dir = abspath(main.chdir ? parentdir(input) : pwd())
+    return cd(dir) do
+        pipeline(addenv(f(args; dir = dir), main.env); stdin = input, stdout = output)
+    end
 end
 
 """


### PR DESCRIPTION
does not work when `ph.x` generates `dyn` files